### PR TITLE
Path Relativization: Metafile and Locator Paths

### DIFF
--- a/deltacat/storage/model/transaction.py
+++ b/deltacat/storage/model/transaction.py
@@ -37,7 +37,6 @@ from deltacat.utils.filesystem import (
     list_directory,
 )
 
-logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s', handlers=[logging.FileHandler('test_log.log'), logging.StreamHandler()])
 class TransactionTimeProvider:
     """
     Provider interface for transaction start and end times. An ideal
@@ -500,37 +499,30 @@ class Transaction(dict):
         with respect to the catalog root directory. 
         """
         clean_catalog_root = "/" + catalog_root.lstrip("/")
-        logging.debug(f"Catalog root: {clean_catalog_root}")
         # handle metafile paths
         metafile_write_paths = []
         abs_metafile_path_len = len(operation.metafile_write_paths)
-        logging.debug(f"Number of meta write paths: {abs_metafile_path_len}")
-        logging.debug(f"Metafile write paths BEFORE: {operation.metafile_write_paths}")
         for path in operation.metafile_write_paths:
             if not path.startswith(clean_catalog_root) or not path.startswith(catalog_root):
-                metafile_write_paths.append(path)
+                metafile_write_paths.append(path) # skip if not in catalog root
                 continue
             path_len = len(path)
             relative_path = Transaction.abs_to_relative(catalog_root, path)
             metafile_write_paths.append(relative_path)
         if len(metafile_write_paths) > 0 and abs_metafile_path_len > 0:
             operation.replace_metafile_write_paths(metafile_write_paths)
-        logging.debug(f"Metafile write paths AFTER: {operation.metafile_write_paths} \n")
         
         # handle locator paths
         locator_write_paths = []
         abs_locator_path_len = len(operation.locator_write_paths)
-        logging.debug(f"Number of loc write paths: {abs_metafile_path_len}")
-        logging.debug(f"locator write paths BEFORE: {operation.locator_write_paths}")
         for path in operation.locator_write_paths:
             if not path.startswith(clean_catalog_root) or not path.startswith(catalog_root):
-                locator_write_paths.append(path)
+                locator_write_paths.append(path) # skip if not in catalog root
                 continue
             relative_path = Transaction.abs_to_relative(catalog_root, path)
             locator_write_paths.append(relative_path)
         if len(locator_write_paths) > 0 and abs_locator_path_len > 0:
             operation.replace_locator_write_paths(locator_write_paths)
-        logging.debug(f"Locator write paths AFTER: {operation.locator_write_paths} \n")
 
     def to_serializable(self, catalog_root) -> Transaction:
         """

--- a/deltacat/tests/storage/model/test_abs_to_relative.py
+++ b/deltacat/tests/storage/model/test_abs_to_relative.py
@@ -1,0 +1,400 @@
+import os
+from typing import List, Tuple
+
+import time
+import multiprocessing
+
+import pyarrow as pa
+import pytest
+
+
+print("this is a test LOL")
+
+from deltacat import (
+    Schema,
+    Field,
+    PartitionScheme,
+    PartitionKey,
+    ContentEncoding,
+    ContentType,
+    SortScheme,
+    SortKey,
+    SortOrder,
+    NullOrder,
+    LifecycleState,
+)
+from deltacat.storage import (
+    BucketTransform,
+    BucketTransformParameters,
+    BucketingStrategy,
+    CommitState,
+    DeltaLocator,
+    Delta,
+    DeltaType,
+    EntryParams,
+    EntryType,
+    Manifest,
+    ManifestAuthor,
+    ManifestEntry,
+    ManifestMeta,
+    Namespace,
+    NamespaceLocator,
+    PartitionLocator,
+    Partition,
+    StreamLocator,
+    StreamFormat,
+    Stream,
+    Table,
+    TableLocator,
+    TableVersionLocator,
+    TableVersion,
+    Transaction,
+    TransactionOperation,
+    TransactionType,
+    TransactionOperationType,
+    TruncateTransform,
+    TruncateTransformParameters,
+)
+from deltacat.storage.model.metafile import (
+    Metafile,
+    MetafileRevisionInfo,
+)
+from deltacat.constants import TXN_DIR_NAME, SUCCESS_TXN_DIR_NAME, NANOS_PER_SEC
+from deltacat.utils.filesystem import resolve_path_and_filesystem
+
+def _commit_single_delta_table(temp_dir: str) -> List[Tuple[Metafile, Metafile, str]]:
+    # namespace
+    namespace_locator = NamespaceLocator.of(namespace="test_namespace")
+    namespace = Namespace.of(locator=namespace_locator)
+
+    # table
+    table_locator = TableLocator.at(
+        namespace="test_namespace",
+        table_name="test_table",
+    )
+    table = Table.of(
+        locator=table_locator,
+        description="test table description",
+    )
+
+    # stream
+    table_version_locator = TableVersionLocator.at(
+        namespace="test_namespace",
+        table_name="test_table",
+        table_version="test_table_version",
+    )
+    schema = Schema.of(
+        [
+            Field.of(
+                field=pa.field("some_string", pa.string(), nullable=False),
+                field_id=1,
+                is_merge_key=True,
+            ),
+            Field.of(
+                field=pa.field("some_int32", pa.int32(), nullable=False),
+                field_id=2,
+                is_merge_key=True,
+            ),
+            Field.of(
+                field=pa.field("some_float64", pa.float64()),
+                field_id=3,
+                is_merge_key=False,
+            ),
+        ]
+    )
+    bucket_transform = BucketTransform.of(
+        BucketTransformParameters.of(
+            num_buckets=2,
+            bucketing_strategy=BucketingStrategy.DEFAULT,
+        )
+    )
+    partition_keys = [
+        PartitionKey.of(
+            key=["some_string", "some_int32"],
+            name="test_partition_key",
+            field_id="test_field_id",
+            transform=bucket_transform,
+        )
+    ]
+    partition_scheme = PartitionScheme.of(
+        keys=partition_keys,
+        name="test_partition_scheme",
+        scheme_id="test_partition_scheme_id",
+    )
+    sort_keys = [
+        SortKey.of(
+            key=["some_int32"],
+            sort_order=SortOrder.DESCENDING,
+            null_order=NullOrder.AT_START,
+            transform=TruncateTransform.of(
+                TruncateTransformParameters.of(width=3),
+            ),
+        )
+    ]
+    sort_scheme = SortScheme.of(
+        keys=sort_keys,
+        name="test_sort_scheme",
+        scheme_id="test_sort_scheme_id",
+    )
+    table_version = TableVersion.of(
+        locator=table_version_locator,
+        schema=schema,
+        partition_scheme=partition_scheme,
+        description="test table version description",
+        properties={"test_property_key": "test_property_value"},
+        content_types=[ContentType.PARQUET],
+        sort_scheme=sort_scheme,
+        watermark=1,
+        lifecycle_state=LifecycleState.CREATED,
+        schemas=[schema, schema, schema],
+        partition_schemes=[partition_scheme, partition_scheme],
+        sort_schemes=[sort_scheme, sort_scheme],
+    )
+
+    stream_locator = StreamLocator.at(
+        namespace="test_namespace",
+        table_name="test_table",
+        table_version="test_table_version",
+        stream_id="test_stream_id",
+        stream_format=StreamFormat.DELTACAT,
+    )
+    bucket_transform = BucketTransform.of(
+        BucketTransformParameters.of(
+            num_buckets=2,
+            bucketing_strategy=BucketingStrategy.DEFAULT,
+        )
+    )
+    partition_keys = [
+        PartitionKey.of(
+            key=["some_string", "some_int32"],
+            name="test_partition_key",
+            field_id="test_field_id",
+            transform=bucket_transform,
+        )
+    ]
+    partition_scheme = PartitionScheme.of(
+        keys=partition_keys,
+        name="test_partition_scheme",
+        scheme_id="test_partition_scheme_id",
+    )
+    stream = Stream.of(
+        locator=stream_locator,
+        partition_scheme=partition_scheme,
+        state=CommitState.STAGED,
+        previous_stream_id="test_previous_stream_id",
+        watermark=1,
+    )
+
+    # partition
+    partition_locator = PartitionLocator.at(
+        namespace="test_namespace",
+        table_name="test_table",
+        table_version="test_table_version",
+        stream_id="test_stream_id",
+        stream_format=StreamFormat.DELTACAT,
+        partition_values=["a", 1],
+        partition_id="test_partition_id",
+    )
+    schema = Schema.of(
+        [
+            Field.of(
+                field=pa.field("some_string", pa.string(), nullable=False),
+                field_id=1,
+                is_merge_key=True,
+            ),
+            Field.of(
+                field=pa.field("some_int32", pa.int32(), nullable=False),
+                field_id=2,
+                is_merge_key=True,
+            ),
+            Field.of(
+                field=pa.field("some_float64", pa.float64()),
+                field_id=3,
+                is_merge_key=False,
+            ),
+        ]
+    )
+    partition = Partition.of(
+        locator=partition_locator,
+        schema=schema,
+        content_types=[ContentType.PARQUET],
+        state=CommitState.STAGED,
+        previous_stream_position=0,
+        previous_partition_id="test_previous_partition_id",
+        stream_position=1,
+        partition_scheme_id="test_partition_scheme_id",
+    )
+
+    # delta
+    delta_locator = DeltaLocator.at(
+        namespace="test_namespace",
+        table_name="test_table",
+        table_version="test_table_version",
+        stream_id="test_stream_id",
+        stream_format=StreamFormat.DELTACAT,
+        partition_values=["a", 1],
+        partition_id="test_partition_id",
+        stream_position=1,
+    )
+    manifest_entry_params = EntryParams.of(
+        equality_field_locators=["some_string", "some_int32"],
+    )
+    manifest_meta = ManifestMeta.of(
+        record_count=1,
+        content_length=10,
+        content_type=ContentType.PARQUET.value,
+        content_encoding=ContentEncoding.IDENTITY.value,
+        source_content_length=100,
+        credentials={"foo": "bar"},
+        content_type_parameters=[{"param1": "value1"}],
+        entry_type=EntryType.EQUALITY_DELETE,
+        entry_params=manifest_entry_params,
+    )
+    manifest = Manifest.of(
+        entries=[
+            ManifestEntry.of(
+                url="s3://test/url",
+                meta=manifest_meta,
+            )
+        ],
+        author=ManifestAuthor.of(
+            name="deltacat",
+            version="2.0",
+        ),
+        entry_type=EntryType.EQUALITY_DELETE,
+        entry_params=manifest_entry_params,
+    )
+    delta = Delta.of(
+        locator=delta_locator,
+        delta_type=DeltaType.APPEND,
+        meta=manifest_meta,
+        properties={"property1": "value1"},
+        manifest=manifest,
+        previous_stream_position=0,
+    )
+    meta_to_create = [
+        namespace,
+        table,
+        table_version,
+        stream,
+        partition,
+        delta,
+    ]
+    txn_operations = [
+        TransactionOperation.of(
+            operation_type=TransactionOperationType.CREATE,
+            dest_metafile=meta,
+        )
+        for meta in meta_to_create
+    ]
+    transaction = Transaction.of(
+        txn_type=TransactionType.APPEND,
+        txn_operations=txn_operations,
+    )
+    write_paths, txn_log_path = transaction.commit(temp_dir)
+    write_paths_copy = write_paths.copy()
+    assert os.path.exists(txn_log_path)
+    metafiles_created = [
+        Delta.read(write_paths.pop()),
+        Partition.read(write_paths.pop()),
+        Stream.read(write_paths.pop()),
+        TableVersion.read(write_paths.pop()),
+        Table.read(write_paths.pop()),
+        Namespace.read(write_paths.pop()),
+    ]
+    metafiles_created.reverse()
+    return list(zip(meta_to_create, metafiles_created, write_paths_copy))
+
+
+def _commit_concurrent_transaction(
+    catalog_root: str,
+    transaction: Transaction,
+) -> None:
+    try:
+        return transaction.commit(catalog_root)
+    except (RuntimeError, ValueError) as e:
+        return e
+
+class TestAbsToRelative:
+    def test_metafile_read_bad_path(self, temp_dir):
+        with pytest.raises(FileNotFoundError):
+            Delta.read("foobar")
+    def test_abs_to_relative(self):
+        print("this is a test LOL")
+        assert 1 == 1
+        assert 2 == 2
+        assert 3 == 3
+        return None
+    def test_replace_delta(self, temp_dir):
+        commit_results = _commit_single_delta_table(temp_dir)
+        for expected, actual, _ in commit_results:
+            assert expected.equivalent_to(actual)
+        original_delta: Delta = commit_results[5][1]
+
+        # given a transaction containing a delta replacement
+        replacement_delta: Delta = Delta.based_on(
+            original_delta,
+            new_id=str(int(original_delta.id) + 1),
+        )
+
+        # expect the proposed replacement delta to be assigned a new ID
+        assert replacement_delta.id != original_delta.id
+
+        txn_operations = [
+            TransactionOperation.of(
+                operation_type=TransactionOperationType.UPDATE,
+                dest_metafile=replacement_delta,
+                src_metafile=original_delta,
+            )
+        ]
+        transaction = Transaction.of(
+            txn_type=TransactionType.OVERWRITE,
+            txn_operations=txn_operations,
+        )
+        # when the transaction is committed
+        write_paths, txn_log_path = transaction.commit(temp_dir)
+
+        # expect two new metafiles to be written
+        # (i.e., delete old delta, create replacement delta)
+        assert len(write_paths) == 2
+        delete_write_path = write_paths[0]
+        create_write_path = write_paths[1]
+
+        # expect the replacement delta to be successfully written and read
+        assert TransactionOperationType.CREATE.value in create_write_path
+        actual_delta = Delta.read(create_write_path)
+        assert replacement_delta.equivalent_to(actual_delta)
+
+        # expect the delete metafile to also contain the replacement delta
+        assert TransactionOperationType.DELETE.value in delete_write_path
+        actual_delta = Delta.read(delete_write_path)
+        assert replacement_delta.equivalent_to(actual_delta)
+
+        # expect a subsequent replace of the original delta to fail
+        bad_txn_operations = [
+            TransactionOperation.of(
+                operation_type=TransactionOperationType.UPDATE,
+                dest_metafile=replacement_delta,
+                src_metafile=original_delta,
+            )
+        ]
+        transaction = Transaction.of(
+            txn_type=TransactionType.OVERWRITE,
+            txn_operations=bad_txn_operations,
+        )
+        with pytest.raises(ValueError):
+            transaction.commit(temp_dir)
+
+        # expect deletes of the original delta to fail
+        bad_txn_operations = [
+            TransactionOperation.of(
+                operation_type=TransactionOperationType.DELETE,
+                dest_metafile=original_delta,
+            )
+        ]
+        transaction = Transaction.of(
+            txn_type=TransactionType.DELETE,
+            txn_operations=bad_txn_operations,
+        )
+        with pytest.raises(ValueError):
+            transaction.commit(temp_dir)

--- a/deltacat/tests/storage/model/test_abs_to_relative.py
+++ b/deltacat/tests/storage/model/test_abs_to_relative.py
@@ -1,400 +1,189 @@
-import os
-from typing import List, Tuple
-
-import time
-import multiprocessing
-
-import pyarrow as pa
 import pytest
 
-
-print("this is a test LOL")
-
-from deltacat import (
-    Schema,
-    Field,
-    PartitionScheme,
-    PartitionKey,
-    ContentEncoding,
-    ContentType,
-    SortScheme,
-    SortKey,
-    SortOrder,
-    NullOrder,
-    LifecycleState,
-)
 from deltacat.storage import (
-    BucketTransform,
-    BucketTransformParameters,
-    BucketingStrategy,
-    CommitState,
-    DeltaLocator,
-    Delta,
-    DeltaType,
-    EntryParams,
-    EntryType,
-    Manifest,
-    ManifestAuthor,
-    ManifestEntry,
-    ManifestMeta,
-    Namespace,
-    NamespaceLocator,
-    PartitionLocator,
-    Partition,
-    StreamLocator,
-    StreamFormat,
-    Stream,
-    Table,
-    TableLocator,
-    TableVersionLocator,
-    TableVersion,
     Transaction,
     TransactionOperation,
     TransactionType,
     TransactionOperationType,
-    TruncateTransform,
-    TruncateTransformParameters,
 )
 from deltacat.storage.model.metafile import (
     Metafile,
-    MetafileRevisionInfo,
 )
-from deltacat.constants import TXN_DIR_NAME, SUCCESS_TXN_DIR_NAME, NANOS_PER_SEC
-from deltacat.utils.filesystem import resolve_path_and_filesystem
-
-def _commit_single_delta_table(temp_dir: str) -> List[Tuple[Metafile, Metafile, str]]:
-    # namespace
-    namespace_locator = NamespaceLocator.of(namespace="test_namespace")
-    namespace = Namespace.of(locator=namespace_locator)
-
-    # table
-    table_locator = TableLocator.at(
-        namespace="test_namespace",
-        table_name="test_table",
-    )
-    table = Table.of(
-        locator=table_locator,
-        description="test table description",
-    )
-
-    # stream
-    table_version_locator = TableVersionLocator.at(
-        namespace="test_namespace",
-        table_name="test_table",
-        table_version="test_table_version",
-    )
-    schema = Schema.of(
-        [
-            Field.of(
-                field=pa.field("some_string", pa.string(), nullable=False),
-                field_id=1,
-                is_merge_key=True,
-            ),
-            Field.of(
-                field=pa.field("some_int32", pa.int32(), nullable=False),
-                field_id=2,
-                is_merge_key=True,
-            ),
-            Field.of(
-                field=pa.field("some_float64", pa.float64()),
-                field_id=3,
-                is_merge_key=False,
-            ),
-        ]
-    )
-    bucket_transform = BucketTransform.of(
-        BucketTransformParameters.of(
-            num_buckets=2,
-            bucketing_strategy=BucketingStrategy.DEFAULT,
-        )
-    )
-    partition_keys = [
-        PartitionKey.of(
-            key=["some_string", "some_int32"],
-            name="test_partition_key",
-            field_id="test_field_id",
-            transform=bucket_transform,
-        )
-    ]
-    partition_scheme = PartitionScheme.of(
-        keys=partition_keys,
-        name="test_partition_scheme",
-        scheme_id="test_partition_scheme_id",
-    )
-    sort_keys = [
-        SortKey.of(
-            key=["some_int32"],
-            sort_order=SortOrder.DESCENDING,
-            null_order=NullOrder.AT_START,
-            transform=TruncateTransform.of(
-                TruncateTransformParameters.of(width=3),
-            ),
-        )
-    ]
-    sort_scheme = SortScheme.of(
-        keys=sort_keys,
-        name="test_sort_scheme",
-        scheme_id="test_sort_scheme_id",
-    )
-    table_version = TableVersion.of(
-        locator=table_version_locator,
-        schema=schema,
-        partition_scheme=partition_scheme,
-        description="test table version description",
-        properties={"test_property_key": "test_property_value"},
-        content_types=[ContentType.PARQUET],
-        sort_scheme=sort_scheme,
-        watermark=1,
-        lifecycle_state=LifecycleState.CREATED,
-        schemas=[schema, schema, schema],
-        partition_schemes=[partition_scheme, partition_scheme],
-        sort_schemes=[sort_scheme, sort_scheme],
-    )
-
-    stream_locator = StreamLocator.at(
-        namespace="test_namespace",
-        table_name="test_table",
-        table_version="test_table_version",
-        stream_id="test_stream_id",
-        stream_format=StreamFormat.DELTACAT,
-    )
-    bucket_transform = BucketTransform.of(
-        BucketTransformParameters.of(
-            num_buckets=2,
-            bucketing_strategy=BucketingStrategy.DEFAULT,
-        )
-    )
-    partition_keys = [
-        PartitionKey.of(
-            key=["some_string", "some_int32"],
-            name="test_partition_key",
-            field_id="test_field_id",
-            transform=bucket_transform,
-        )
-    ]
-    partition_scheme = PartitionScheme.of(
-        keys=partition_keys,
-        name="test_partition_scheme",
-        scheme_id="test_partition_scheme_id",
-    )
-    stream = Stream.of(
-        locator=stream_locator,
-        partition_scheme=partition_scheme,
-        state=CommitState.STAGED,
-        previous_stream_id="test_previous_stream_id",
-        watermark=1,
-    )
-
-    # partition
-    partition_locator = PartitionLocator.at(
-        namespace="test_namespace",
-        table_name="test_table",
-        table_version="test_table_version",
-        stream_id="test_stream_id",
-        stream_format=StreamFormat.DELTACAT,
-        partition_values=["a", 1],
-        partition_id="test_partition_id",
-    )
-    schema = Schema.of(
-        [
-            Field.of(
-                field=pa.field("some_string", pa.string(), nullable=False),
-                field_id=1,
-                is_merge_key=True,
-            ),
-            Field.of(
-                field=pa.field("some_int32", pa.int32(), nullable=False),
-                field_id=2,
-                is_merge_key=True,
-            ),
-            Field.of(
-                field=pa.field("some_float64", pa.float64()),
-                field_id=3,
-                is_merge_key=False,
-            ),
-        ]
-    )
-    partition = Partition.of(
-        locator=partition_locator,
-        schema=schema,
-        content_types=[ContentType.PARQUET],
-        state=CommitState.STAGED,
-        previous_stream_position=0,
-        previous_partition_id="test_previous_partition_id",
-        stream_position=1,
-        partition_scheme_id="test_partition_scheme_id",
-    )
-
-    # delta
-    delta_locator = DeltaLocator.at(
-        namespace="test_namespace",
-        table_name="test_table",
-        table_version="test_table_version",
-        stream_id="test_stream_id",
-        stream_format=StreamFormat.DELTACAT,
-        partition_values=["a", 1],
-        partition_id="test_partition_id",
-        stream_position=1,
-    )
-    manifest_entry_params = EntryParams.of(
-        equality_field_locators=["some_string", "some_int32"],
-    )
-    manifest_meta = ManifestMeta.of(
-        record_count=1,
-        content_length=10,
-        content_type=ContentType.PARQUET.value,
-        content_encoding=ContentEncoding.IDENTITY.value,
-        source_content_length=100,
-        credentials={"foo": "bar"},
-        content_type_parameters=[{"param1": "value1"}],
-        entry_type=EntryType.EQUALITY_DELETE,
-        entry_params=manifest_entry_params,
-    )
-    manifest = Manifest.of(
-        entries=[
-            ManifestEntry.of(
-                url="s3://test/url",
-                meta=manifest_meta,
-            )
-        ],
-        author=ManifestAuthor.of(
-            name="deltacat",
-            version="2.0",
-        ),
-        entry_type=EntryType.EQUALITY_DELETE,
-        entry_params=manifest_entry_params,
-    )
-    delta = Delta.of(
-        locator=delta_locator,
-        delta_type=DeltaType.APPEND,
-        meta=manifest_meta,
-        properties={"property1": "value1"},
-        manifest=manifest,
-        previous_stream_position=0,
-    )
-    meta_to_create = [
-        namespace,
-        table,
-        table_version,
-        stream,
-        partition,
-        delta,
-    ]
-    txn_operations = [
-        TransactionOperation.of(
-            operation_type=TransactionOperationType.CREATE,
-            dest_metafile=meta,
-        )
-        for meta in meta_to_create
-    ]
-    transaction = Transaction.of(
-        txn_type=TransactionType.APPEND,
-        txn_operations=txn_operations,
-    )
-    write_paths, txn_log_path = transaction.commit(temp_dir)
-    write_paths_copy = write_paths.copy()
-    assert os.path.exists(txn_log_path)
-    metafiles_created = [
-        Delta.read(write_paths.pop()),
-        Partition.read(write_paths.pop()),
-        Stream.read(write_paths.pop()),
-        TableVersion.read(write_paths.pop()),
-        Table.read(write_paths.pop()),
-        Namespace.read(write_paths.pop()),
-    ]
-    metafiles_created.reverse()
-    return list(zip(meta_to_create, metafiles_created, write_paths_copy))
-
-
-def _commit_concurrent_transaction(
-    catalog_root: str,
-    transaction: Transaction,
-) -> None:
-    try:
-        return transaction.commit(catalog_root)
-    except (RuntimeError, ValueError) as e:
-        return e
 
 class TestAbsToRelative:
-    def test_metafile_read_bad_path(self, temp_dir):
-        with pytest.raises(FileNotFoundError):
-            Delta.read("foobar")
-    def test_abs_to_relative(self):
-        print("this is a test LOL")
-        assert 1 == 1
-        assert 2 == 2
-        assert 3 == 3
-        return None
-    def test_replace_delta(self, temp_dir):
-        commit_results = _commit_single_delta_table(temp_dir)
-        for expected, actual, _ in commit_results:
-            assert expected.equivalent_to(actual)
-        original_delta: Delta = commit_results[5][1]
-
-        # given a transaction containing a delta replacement
-        replacement_delta: Delta = Delta.based_on(
-            original_delta,
-            new_id=str(int(original_delta.id) + 1),
-        )
-
-        # expect the proposed replacement delta to be assigned a new ID
-        assert replacement_delta.id != original_delta.id
-
-        txn_operations = [
-            TransactionOperation.of(
-                operation_type=TransactionOperationType.UPDATE,
-                dest_metafile=replacement_delta,
-                src_metafile=original_delta,
-            )
+    ### Test cases for the abs_to_relative function
+    def test_abs_to_relative_simple(self):
+        """
+        Tests the function which performs relativization of absolute paths
+        """
+        catalog_root = "/catalog/root/path"
+        absolute_path = "/catalog/root/path/namespace/table/table_version/stream_id/partition_id/00000000000000000001.mpk"
+        relative_path = Transaction.abs_to_relative(catalog_root, absolute_path)
+        assert relative_path == "namespace/table/table_version/stream_id/partition_id/00000000000000000001.mpk"
+        
+    def test_abs_to_relative_bad_root(self):
+        catalog_root = "/catalog/root/path"
+        absolute_path = "/cat/rt/pth/namespace/table/table_version/stream_id/partition_id/00000000000000000001.mpk"
+        with pytest.raises(ValueError, match="Target path is not within the catalog root"):
+            Transaction.abs_to_relative(catalog_root, absolute_path)
+            
+    def test_abs_to_relative_empty_path(self):
+        with pytest.raises(ValueError, match="Invalid directory paths"):
+            Transaction.abs_to_relative("", "lorem/ipsum")
+            
+    ### Test cases for the relativize_operation_paths function
+    def test_relativize_metafile_write_paths(self):
+        catalog_root = "/catalog/root"
+        absolute_paths = [
+            "/catalog/root/path/to/metafile1.mpk",
+            "/catalog/root/path/to/metafile2.mpk",
+            "/catalog/root/another/path/lore_ipsum.mpk",
+            "/catalog/root/another/path/meta/to/lorem_ipsum.mpk",
+            "/catalog/root/another/path/lorem_ipsum.mpk",
+            "/catalog/root/here.mpk"
         ]
-        transaction = Transaction.of(
-            txn_type=TransactionType.OVERWRITE,
-            txn_operations=txn_operations,
-        )
-        # when the transaction is committed
-        write_paths, txn_log_path = transaction.commit(temp_dir)
-
-        # expect two new metafiles to be written
-        # (i.e., delete old delta, create replacement delta)
-        assert len(write_paths) == 2
-        delete_write_path = write_paths[0]
-        create_write_path = write_paths[1]
-
-        # expect the replacement delta to be successfully written and read
-        assert TransactionOperationType.CREATE.value in create_write_path
-        actual_delta = Delta.read(create_write_path)
-        assert replacement_delta.equivalent_to(actual_delta)
-
-        # expect the delete metafile to also contain the replacement delta
-        assert TransactionOperationType.DELETE.value in delete_write_path
-        actual_delta = Delta.read(delete_write_path)
-        assert replacement_delta.equivalent_to(actual_delta)
-
-        # expect a subsequent replace of the original delta to fail
-        bad_txn_operations = [
-            TransactionOperation.of(
-                operation_type=TransactionOperationType.UPDATE,
-                dest_metafile=replacement_delta,
-                src_metafile=original_delta,
-            )
+        expected_relative_paths = [
+            "path/to/metafile1.mpk",
+            "path/to/metafile2.mpk",
+            "another/path/lore_ipsum.mpk",
+            "another/path/meta/to/lorem_ipsum.mpk",
+            "another/path/lorem_ipsum.mpk",
+            "here.mpk",
         ]
-        transaction = Transaction.of(
-            txn_type=TransactionType.OVERWRITE,
-            txn_operations=bad_txn_operations,
+        # Create a dummy transaction operation with absolute paths
+        dest_metafile = Metafile({"id": "dummy_metafile_id"})
+        transaction_operation = TransactionOperation.of(
+            operation_type=TransactionOperationType.CREATE,
+            dest_metafile=dest_metafile,
         )
-        with pytest.raises(ValueError):
-            transaction.commit(temp_dir)
+        # use replace method as setter
+        transaction_operation.replace_metafile_write_paths(absolute_paths)
+        # Create a transaction and relativize paths
+        transaction = Transaction.of(txn_type=TransactionType.APPEND, txn_operations=[transaction_operation])
+        transaction.relativize_operation_paths(transaction_operation, catalog_root)
+        # Verify the paths have been correctly relativized
+        assert transaction_operation.metafile_write_paths == expected_relative_paths
 
-        # expect deletes of the original delta to fail
-        bad_txn_operations = [
-            TransactionOperation.of(
-                operation_type=TransactionOperationType.DELETE,
-                dest_metafile=original_delta,
-            )
+    def test_relativize_locator_write_paths(self):
+        catalog_root = "/catalog/root"
+        absolute_paths = [
+            "/catalog/root/path/to/loc1.mpk",
+            "/catalog/root/path/to/loc2.mpk",
+            "/catalog/root/another/path/lore_ipsum.mpk",
+            "/catalog/root/another/path/meta/to/lorem_ipsum.mpk",
+            "/catalog/root/another/path/lorem_ipsum.mpk",
+            "/catalog/root/here.mpk"
         ]
-        transaction = Transaction.of(
-            txn_type=TransactionType.DELETE,
-            txn_operations=bad_txn_operations,
+        expected_relative_paths = [
+            "path/to/loc1.mpk",
+            "path/to/loc2.mpk",
+            "another/path/lore_ipsum.mpk",
+            "another/path/meta/to/lorem_ipsum.mpk",
+            "another/path/lorem_ipsum.mpk",
+            "here.mpk",
+        ]
+        # Create a dummy transaction operation with absolute paths
+        dest_metafile = Metafile({"id": "dummy_metafile_id"})
+        transaction_operation = TransactionOperation.of(
+            operation_type=TransactionOperationType.CREATE,
+            dest_metafile=dest_metafile,
         )
-        with pytest.raises(ValueError):
-            transaction.commit(temp_dir)
+        # use replace as setter
+        transaction_operation.replace_locator_write_paths(absolute_paths)
+        # Create a transaction and relativize paths
+        transaction = Transaction.of(txn_type=TransactionType.APPEND, txn_operations=[transaction_operation])
+        transaction.relativize_operation_paths(transaction_operation, catalog_root)
+        # Verify the paths have been correctly relativized
+        assert transaction_operation.locator_write_paths == expected_relative_paths
+        
+    def test_relativize_metafile_and_locator_paths(self):
+        catalog_root = "/meta_catalog/root_dir/a/b/c"
+        meta_absolute_paths = [
+            "/meta_catalog/root_dir/a/b/c/namespace/table/table_version/stream_id/partition_id/00000000000000000001.mpk",
+            "/meta_catalog/root_dir/a/b/c/namespace/table/table_version/stream_id/partition_id/00000000000000000002.mpk",
+            "/meta_catalog/root_dir/a/b/c/namespace/table/table_version/stream_id/partition_id/00000000000000000003.mpk",
+        ]
+        loc_absolute_paths = [
+            "/meta_catalog/root_dir/a/b/c/d/table/table_version/stream_id/partition_id/00000000000000000001.mpk",
+            "/meta_catalog/root_dir/a/b/c/e/table/table_version/stream_id/partition_id/00000000000000000002.mpk",
+            "/meta_catalog/root_dir/a/b/c/f/table/table_version/stream_id/partition_id/00000000000000000003.mpk",
+        ]
+        meta_relative_paths = [
+            "namespace/table/table_version/stream_id/partition_id/00000000000000000001.mpk",
+            "namespace/table/table_version/stream_id/partition_id/00000000000000000002.mpk",
+            "namespace/table/table_version/stream_id/partition_id/00000000000000000003.mpk",
+        ]
+        loc_relative_paths = [
+            "d/table/table_version/stream_id/partition_id/00000000000000000001.mpk",
+            "e/table/table_version/stream_id/partition_id/00000000000000000002.mpk",
+            "f/table/table_version/stream_id/partition_id/00000000000000000003.mpk",
+        ]
+        # Create a dummy transaction operation with absolute paths
+        dest_metafile = Metafile({"id": "dummy_metafile_id"})
+        transaction_operation = TransactionOperation.of(
+            operation_type=TransactionOperationType.CREATE,
+            dest_metafile=dest_metafile,
+        )
+        # use replace as setter
+        transaction_operation.replace_metafile_write_paths(meta_absolute_paths)
+        transaction_operation.replace_locator_write_paths(loc_absolute_paths)
+        # Create a transaction and relativize paths
+        transaction = Transaction.of(txn_type=TransactionType.APPEND, txn_operations=[transaction_operation])
+        transaction.relativize_operation_paths(transaction_operation, catalog_root)
+        # Verify the paths have been correctly relativized
+        assert transaction_operation.metafile_write_paths == meta_relative_paths, f"Expected: {meta_relative_paths}, but got: {transaction_operation.metafile_write_paths}"
+        assert transaction_operation.locator_write_paths == loc_relative_paths, f"Expected: {loc_relative_paths}, but got: {transaction_operation.locator_write_paths}"
+
+    def test_multiple_operations_relativize_paths(self):
+        catalog_root = "/catalog/root"
+        meta_absolute_paths = [
+            "/catalog/root/path/to/metafile1.mpk",
+            "/catalog/root/path/to/metafile2.mpk",
+            "/catalog/root/another/path/lore_ipsum.mpk",
+            "/catalog/root/another/path/meta/to/lorem_ipsum.mpk",
+            "/catalog/root/another/path/lorem_ipsum.mpk",
+            "/catalog/root/here.mpk"
+        ]
+        loc_absolute_paths = [
+            "/catalog/root/path/to/loc1.mpk",
+            "/catalog/root/path/to/loc2.mpk",
+            "/catalog/root/another/path/lore_ipsum.mpk",
+            "/catalog/root/another/path/meta/to/lorem_ipsum.mpk",
+            "/catalog/root/another/path/lorem_ipsum.mpk",
+            "/catalog/root/here.mpk"
+        ]
+        meta_expected_relative_paths = [
+            "path/to/metafile1.mpk",
+            "path/to/metafile2.mpk",
+            "another/path/lore_ipsum.mpk",
+            "another/path/meta/to/lorem_ipsum.mpk",
+            "another/path/lorem_ipsum.mpk",
+            "here.mpk",
+        ]
+        loc_expected_relative_paths = [
+            "path/to/loc1.mpk",
+            "path/to/loc2.mpk",
+            "another/path/lore_ipsum.mpk",
+            "another/path/meta/to/lorem_ipsum.mpk",
+            "another/path/lorem_ipsum.mpk",
+            "here.mpk",
+        ]
+        # Create a dummy transaction operation with absolute paths
+        dest_metafile = Metafile({"id": "dummy_metafile_id"})
+        transaction_operations = []
+        for i in range(11):
+            transaction_operation = TransactionOperation.of(
+                operation_type=TransactionOperationType.CREATE,
+                dest_metafile=dest_metafile,
+            )
+            transaction_operation.replace_metafile_write_paths(meta_absolute_paths)
+            transaction_operation.replace_locator_write_paths(loc_absolute_paths)
+            transaction_operations.append(transaction_operation)
+        # Create a transaction and relativize paths
+        transaction = Transaction.of(txn_type=TransactionType.APPEND, txn_operations=transaction_operations)
+        for operation in transaction_operations:
+            transaction.relativize_operation_paths(operation, catalog_root)
+        # Verify the paths have been correctly relativized
+        for operation in transaction_operations:
+            assert operation.metafile_write_paths == meta_expected_relative_paths
+            assert operation.locator_write_paths == loc_expected_relative_paths


### PR DESCRIPTION
## Summary

Implemented path relativization for paths embedded within the metafile and locator metadata of individual transaction operations. This occurs prior to serializing the transaction object to ensure relative paths are used throughout.

## Rationale

The introduction of path relativization improves system portability by enabling dynamic resolution of paths relative to the catalog root. This simplifies user-specific configurations and enhances flexibility in permission management across different environments.

## Changes

- Modified `deltacat/storage/model/transaction.py` by implementing the relativization method. This includes the addition of operation-level logic and comprehensive error handling. The `to_serializable()` method has been refactored to accept the catalog root path, providing the necessary context for the relativization process.

- Added a new test file `deltacat/tests/storage/model/test_abs_to_relative.py`, to verify the correctness of the relativization logic. The tests include both unit tests for the helper functions and integration tests that simulate real-world transactions and operations.

## Impact

All tests have passed successfully, indicating that the changes do not break existing functionality. Further testing is recommended to ensure compatibility with all potential use cases and that no unintended regressions have been introduced.

## Testing

- The test suite `deltacat/tests/storage/model/test_abs_to_relative.py` was added to validate the new relativization logic. The tests cover both the functionality of individual helper methods and full integration via mock transactions and operations.
